### PR TITLE
Fix for non-repo container urls

### DIFF
--- a/lib/models/instance.js
+++ b/lib/models/instance.js
@@ -320,11 +320,10 @@ Instance.prototype.getContainerHostname = function () {
     isolated: this.attrs.isolated,
     isIsolationGroupMaster: this.attrs.isIsolationGroupMaster
   };
-  if (!branchName) {
-    // If there is no branch there is only elastic url's
-    return runnableHostname.elastic(opts);
-  }
-  return runnableHostname.direct(opts);
+  // NON-REPO CONTAINERS CAN HAVE DIRECT URLS
+  return (this.attrs.masterPod && !branchName) ?
+    runnableHostname.elastic(opts): // masterPods w/out branch don't have direct urls
+    runnableHostname.direct(opts);
 };
 
 /**


### PR DESCRIPTION
Non-repos can have direct urls.  This functionality was removed on accident before being pushed
