### PR TITLE
Add promises add fetch for isolated instance

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -20,7 +20,6 @@ var hasProps = require('101/has-properties');
 var exists = require('101/exists');
 var qs = require('querystring');
 var Promise = require('bluebird');
-var createCount = require('callback-count')
 
 function isMasterHostnameErr (err) {
   return keypather.get(err, 'output.payload.message') === masterHostnameErrMessage;
@@ -364,7 +363,6 @@ User.prototype.fetchBackendForUrl = function (url, referer, cb) {
   if (referer) {
     var refererQuery = {
       hostname: parseUrl(referer).hostname
-      // TODO: masterPod: false
     };
     this._fetchInstanceAndDepWithHostname(refererQuery, parsedUrl.hostname, function (err, dep, instance) {
       if (err && !isInvalidHostnameErr(err)) {
@@ -406,22 +404,22 @@ User.prototype._fetchMasterInstanceByHostname = function (hostname, isolated, cb
     master: this.fetchInstancesAsync({
       hostname: hostname,
       masterPod: true
-    }).get(0)
+    })
   };
   if (isolated) {
     promiseProps.isolated = this.fetchInstancesAsync({
       hostname: hostname,
       isolated: isolated
-    }).get(0);
+    });
   }
   Promise.props(promiseProps)
     .then(function (results) {
-      return results.isolated || results.master;
+      return  keypather.get(results, 'isolated.models[0]') || keypather.get(results, 'master.models[0]');
     })
     .then(function (instance) {
       if (!instance) {
         // this error message is used by isMasterHostnameErr method
-        throw Boom.create(400, masterHostnameErrMessage, {hostname: hostname});
+        throw Boom.create(400, masterHostnameErrMessage, { hostname: hostname, isolated: isolated });
       }
       return instance;
     })

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -188,40 +188,40 @@ User.prototype.oauthId = function () {
  */
 User.prototype.fetchInternalIpForHostname = function (hostname, containerLocalIp, localDockHost, cb) {
   var self = this;
-    // masterInstance exists
-    var refererQuery = {
-      'container.inspect.NetworkSettings.IPAddress': containerLocalIp,
-      'container.dockerHost': localDockHost
-    };
-    self._fetchInstanceAndDepWithHostname(refererQuery, hostname, function (err, dep, instance) {
+  // masterInstance exists
+  var refererQuery = {
+    'container.inspect.NetworkSettings.IPAddress': containerLocalIp,
+    'container.dockerHost': localDockHost
+  };
+  self._fetchInstanceAndDepWithHostname(refererQuery, hostname, function (err, dep, instance) {
+    if (err) {
+      if (isInvalidHostnameErr(err)) {
+        err.errorType = 'invalid-hostname';
+      }
+      return cb(err);
+    }
+
+    // Check if the dependency has a host ip
+    if (hasHostIp(dep)) {
+      return cb(null, dep.attrs.network.hostIp);
+    }
+    self._fetchMasterInstanceByHostname(hostname, keypather.get(instance, 'attrs.isolated'), function (err, masterInstance) {
       if (err) {
-        if (isInvalidHostnameErr(err)) {
+        if (isMasterHostnameErr(err)) {
+          err.errorType = 'not-master-hostname';
+        }
+        else if (isInvalidHostnameErr(err)) {
           err.errorType = 'invalid-hostname';
         }
         return cb(err);
       }
-
-      // Check if the dependency has a host ip
-      if (hasHostIp(dep)) {
-        return cb(null, dep.attrs.network.hostIp);
+       // Check the master instance for a host ip
+      if (hasHostIp(masterInstance)) {
+        return cb(null, masterInstance.attrs.network.hostIp);
       }
-      self._fetchMasterInstanceByHostname(hostname, keypather.get(instance, 'attrs.isolated'), function (err, masterInstance) {
-        if (err) {
-          if (isMasterHostnameErr(err)) {
-            err.errorType = 'not-master-hostname';
-          }
-          else if (isInvalidHostnameErr(err)) {
-            err.errorType = 'invalid-hostname';
-          }
-          return cb(err);
-        }
-         // Check the master instance for a host ip
-        if (hasHostIp(masterInstance)) {
-          return cb(null, masterInstance.attrs.network.hostIp);
-        }
 
-        // If neither have one then error gracefully
-        cb(new Error('Master instance missing `network.hostIp`'));
+      // If neither have one then error gracefully
+      cb(new Error('Master instance missing `network.hostIp`'));
     });
   });
 

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -20,6 +20,7 @@ var hasProps = require('101/has-properties');
 var exists = require('101/exists');
 var qs = require('querystring');
 var Promise = require('bluebird');
+var createCount = require('callback-count')
 
 function isMasterHostnameErr (err) {
   return keypather.get(err, 'output.payload.message') === masterHostnameErrMessage;
@@ -336,7 +337,6 @@ function validateContainer (container) {
 /**
  * get backend url for a master pod instance url
  * @param  {String}   url        master pod instance url
- * @param  {String}   name       master pod instance name
  * @param  {String}   referer    http request referer (possible pod instance url) (can be undefined)
  * @param  {Function} cb  (err, host)
  *                        host format: <protocol>://<host>:<port>
@@ -354,24 +354,30 @@ User.prototype.fetchBackendForUrl = function (url, referer, cb) {
     });
     return cb(err);
   }
-  this._fetchMasterInstanceByHostname(parsedUrl.hostname, function (err, masterInstance) {
-    if (err) { return cb(err); }
-    // masterInstance guaranteed to exist, else 404 error
-    if (!referer) {
+  function fetchMaster(instance) {
+    self._fetchMasterInstanceByHostname(parsedUrl.hostname, keypather.get(instance, 'attrs.isolated'), function (err, masterInstance) {
+      if (err) { return cb(err); }
+      // masterInstance guaranteed to exist, else 404 error
       return validateAndCbBackend(masterInstance, urlPort, cb);
-    }
-
+    });
+  }
+  if (referer) {
     var refererQuery = {
       hostname: parseUrl(referer).hostname
       // TODO: masterPod: false
     };
-    self._fetchInstanceAndDepWithHostname(refererQuery, parsedUrl.hostname, function (err, dep) {
+    this._fetchInstanceAndDepWithHostname(refererQuery, parsedUrl.hostname, function (err, dep, instance) {
       if (err && !isInvalidHostnameErr(err)) {
         return cb(err);
       }
-      return validateAndCbBackend(dep || masterInstance, urlPort, cb);
+      if (dep) {
+        return validateAndCbBackend(dep, urlPort, cb);
+      }
+      return fetchMaster(instance);
     });
-  });
+  } else {
+    fetchMaster()
+  }
 };
 
 User.prototype.fetchInstancesAsync = function (query) {

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -205,7 +205,7 @@ User.prototype.fetchInternalIpForHostname = function (hostname, containerLocalIp
       if (hasHostIp(dep)) {
         return cb(null, dep.attrs.network.hostIp);
       }
-      self._fetchMasterInstanceByHostname(hostname, keypather.get(instance, 'isolated'), function (err, masterInstance) {
+      self._fetchMasterInstanceByHostname(hostname, keypather.get(instance, 'attrs.isolated'), function (err, masterInstance) {
         if (err) {
           if (isMasterHostnameErr(err)) {
             err.errorType = 'not-master-hostname';
@@ -388,6 +388,8 @@ User.prototype.fetchInstancesAsync = function (query) {
  * @param {String}   hostname hostname of the instance's url
  * @param {Boolean}  isolated - isolated property of the instance(s)
  * @param {Function} cb       callback(err, instanceModel) // Never calls back a null model
+ * @throws {Boom.400} throws when no instance has been found
+ * @throws {Error} from fetchInstances
  */
 User.prototype._fetchMasterInstanceByHostname = function (hostname, isolated, cb) {
   if (isFunction(isolated)) {
@@ -423,7 +425,7 @@ User.prototype._fetchMasterInstanceByHostname = function (hostname, isolated, cb
 
 /**
  * find an instance with the query and find its dependency with the shared hostname
- * @param  {String}   query          instance url
+ * @param  {Object}   query          instance url
  * @param  {String}   hostname       instance dependency hostname (shared with master pod)
  * @param  {Function} cb             callback(err, dep) // can callback null dep
  */

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -3,6 +3,7 @@
 
 var util = require('util');
 var isString = require('101/is-string');
+var isFunction = require('101/is-function');
 var ApiClient = require('../api-client');
 var Socket = require('../socket');
 var modelStore = require('../stores/model-store');
@@ -18,6 +19,7 @@ var find = require('101/find');
 var hasProps = require('101/has-properties');
 var exists = require('101/exists');
 var qs = require('querystring');
+var Promise = require('bluebird');
 
 function isMasterHostnameErr (err) {
   return keypather.get(err, 'output.payload.message') === masterHostnameErrMessage;
@@ -191,7 +193,7 @@ User.prototype.fetchInternalIpForHostname = function (hostname, containerLocalIp
       'container.inspect.NetworkSettings.IPAddress': containerLocalIp,
       'container.dockerHost': localDockHost
     };
-    self._fetchInstanceAndDepWithHostname(refererQuery, hostname, function (err, dep) {
+    self._fetchInstanceAndDepWithHostname(refererQuery, hostname, function (err, dep, instance) {
       if (err) {
         if (isInvalidHostnameErr(err)) {
           err.errorType = 'invalid-hostname';
@@ -203,7 +205,7 @@ User.prototype.fetchInternalIpForHostname = function (hostname, containerLocalIp
       if (hasHostIp(dep)) {
         return cb(null, dep.attrs.network.hostIp);
       }
-      self._fetchMasterInstanceByHostname(hostname, function (err, masterInstance) {
+      self._fetchMasterInstanceByHostname(hostname, keypather.get(instance, 'isolated'), function (err, masterInstance) {
         if (err) {
           if (isMasterHostnameErr(err)) {
             err.errorType = 'not-master-hostname';
@@ -372,26 +374,51 @@ User.prototype.fetchBackendForUrl = function (url, referer, cb) {
   });
 };
 
+User.prototype.fetchInstancesAsync = function (query) {
+  var self = this;
+  return Promise.fromCallback(function (cb) {
+    var instances = self.fetchInstances(query, function (err) {
+      cb(err, instances)
+    });
+  });
+};
+
 /**
  * fetch master instance by hostname
- * @param  {String}   hostname hostname of the instance's url
- * @param  {Function} cb       callback(err, instanceModel) // Never calls back a null model
+ * @param {String}   hostname hostname of the instance's url
+ * @param {Boolean}  isolated - isolated property of the instance(s)
+ * @param {Function} cb       callback(err, instanceModel) // Never calls back a null model
  */
-User.prototype._fetchMasterInstanceByHostname = function (hostname, cb) {
-  var query = {
-    hostname: hostname,
-    masterPod: true
+User.prototype._fetchMasterInstanceByHostname = function (hostname, isolated, cb) {
+  if (isFunction(isolated)) {
+    cb = isolated;
+    isolated = null;
+  }
+  var promiseProps = {
+    master: this.fetchInstancesAsync({
+      hostname: hostname,
+      masterPod: true
+    }).get(0)
   };
-  var instances = this.fetchInstances(query, function (err) {
-    if (err) { return cb(err); }
-    var masterInstance = instances.models[0];
-    if (!masterInstance) {
-      // this error message is used by isMasterHostnameErr method
-      err = Boom.create(400, masterHostnameErrMessage, { hostname: hostname });
-      return cb(err);
-    }
-    cb(null, masterInstance);
-  });
+  if (isolated) {
+    promiseProps.isolated = this.fetchInstancesAsync({
+      hostname: hostname,
+      isolated: isolated
+    }).get(0);
+  }
+  Promise.props(promiseProps)
+    .then(function (results) {
+      return results.isolated || results.master;
+    })
+    .then(function (instance) {
+      if (!instance) {
+        // this error message is used by isMasterHostnameErr method
+        throw Boom.create(400, masterHostnameErrMessage, {hostname: hostname});
+      }
+      return instance;
+    })
+    .asCallback(cb)
+
 };
 
 /**
@@ -413,7 +440,7 @@ User.prototype._fetchInstanceAndDepWithHostname = function (query, hostname, cb)
     // Using that instance, fetch it's dependencies that match the target hostname
     var deps = instance.fetchDependencies(query2, function (err) {
       // This should be the specific instance THIS container is attempting to go to
-      cb(err, deps.models[0]);
+      cb(err, deps.models[0], instance);
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@runnable/hostname": "^3.0.0",
     "bluebird": "^3.3.5",
     "boom": "~2.4.1",
-    "callback-count": "^0.2.0",
     "clone": "^1.0.2",
     "debug": "~0.8.1",
     "deep-equal": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "101": "^1.1.0",
     "@runnable/hostname": "^3.0.0",
+    "bluebird": "^3.3.5",
     "boom": "~2.4.1",
     "clone": "^1.0.2",
     "debug": "~0.8.1",
@@ -44,6 +45,7 @@
     "keypather": "^1.8.1",
     "request": "^2.36.0",
     "simple-api-client": "~0.6.0",
+    "sinon-as-promised": "^4.0.0",
     "url-join": "0.0.1",
     "uuid": "~1.4.1",
     "xtend": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@runnable/hostname": "^3.0.0",
     "bluebird": "^3.3.5",
     "boom": "~2.4.1",
+    "callback-count": "^0.2.0",
     "clone": "^1.0.2",
     "debug": "~0.8.1",
     "deep-equal": "^1.0.0",

--- a/test/unit-user.js
+++ b/test/unit-user.js
@@ -246,7 +246,8 @@ describe('user', function () {
             },
             container: {
               dockerHost: '10.20.0.0'
-            }
+            },
+            isolated: 'asdfsadfasdfsd'
           }
         };
         ctx.mockDep = {
@@ -270,7 +271,7 @@ describe('user', function () {
         it('should cb internal ip of master instance if dep not found', function (done) {
           var hostname = 'api-codenow.runnableapp.com';
           var localIp = '10.0.3.0';
-          ctx.fetchDepSpy.yieldsAsync(null, null);
+          ctx.fetchDepSpy.yieldsAsync(null, null, ctx.mockInstance);
           ctx.fetchMasterSpy.yieldsAsync(null, ctx.mockInstance);
           ctx.user.fetchInternalIpForHostname(hostname, localIp, dockerHost, function (err, hostIp) {
             expect(err).to.not.exist();
@@ -285,6 +286,7 @@ describe('user', function () {
             expect(ctx.fetchDepSpy.firstCall.args[1]).to.equal(hostname);
             expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
             expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(hostname);
+            expect(ctx.fetchMasterSpy.firstCall.args[1]).to.deep.equal('asdfsadfasdfsd');
 
             done();
           });

--- a/test/unit-user.js
+++ b/test/unit-user.js
@@ -7,6 +7,7 @@ var noop = require('101/noop');
 var assign = require('101/assign');
 var parseUrl = require('url').parse;
 var Boom = require('boom');
+require('sinon-as-promised')(require('bluebird'))
 
 describe('user', function () {
   var ctx;
@@ -232,6 +233,88 @@ describe('user', function () {
         });
       });
     });
+    describe('_fetchMasterInstanceByHostname', function () {
+      beforeEach(function (done) {
+        ctx.mockInstance = {
+          attrs: {
+            owner: {
+              username: 'tjmehta'
+            },
+            network: {
+              hostIp: 'http://10.0.1.0'
+            },
+            container: {
+              dockerHost: '10.20.0.0'
+            }
+          }
+        };
+        ctx.mockDep = {
+          attrs: {
+            network: {
+              hostIp: 'http://10.0.2.0'
+            }
+          }
+        };
+        ctx.fetchInstancesAsync = sinon.stub(ctx.user, 'fetchInstancesAsync');
+        done();
+      });
+      afterEach(function (done) {
+        ctx.fetchInstancesAsync.restore();
+        done();
+      });
+
+      describe('success', function () {
+        it('should cb internal ip of master instance if not isolated', function (done) {
+          var hostname = 'api-codenow.runnableapp.com';
+          ctx.fetchInstancesAsync.onFirstCall().resolves([ctx.mockInstance]);
+          ctx.fetchInstancesAsync.onSecondCall().resolves([ctx.mockDep]);
+          ctx.user._fetchMasterInstanceByHostname(hostname, false, function (err, instance) {
+            expect(err).to.not.exist();
+            expect(instance).to.exist();
+            expect(instance).to.equal(ctx.mockInstance);
+            done();
+          });
+        });
+
+        it('should cb internal ip of master instance if not isolated', function (done) {
+          var hostname = 'api-codenow.runnableapp.com';
+          ctx.fetchInstancesAsync.onFirstCall().resolves([ctx.mockInstance]);
+          ctx.fetchInstancesAsync.onSecondCall().resolves([ctx.mockDep]);
+          ctx.user._fetchMasterInstanceByHostname(hostname, true, function (err, instance) {
+            expect(err).to.not.exist();
+            expect(instance).to.exist();
+            expect(instance).to.equal(ctx.mockDep);
+            done();
+          });
+        });
+      });
+      describe('error', function () {
+        it('should throw hostname error when no instances return', function (done) {
+          var hostname = 'api-codenow.runnableapp.com';
+          ctx.fetchInstancesAsync.onFirstCall().resolves([]);
+          ctx.fetchInstancesAsync.onSecondCall().resolves([]);
+          ctx.user._fetchMasterInstanceByHostname(hostname, false, function (err, instance) {
+            expect(err).to.exist();
+            expect(instance).to.not.exist();
+            expect(err.message).to.equal('not a master hostname');
+            done();
+          });
+        });
+
+        it('should return error from the instance fetch', function (done) {
+          var hostname = 'api-codenow.runnableapp.com';
+          var error = new Error('BLARG');
+          ctx.fetchInstancesAsync.onFirstCall().resolves([]);
+          ctx.fetchInstancesAsync.onSecondCall().rejects(error);
+          ctx.user._fetchMasterInstanceByHostname(hostname, true, function (err, instance) {
+            expect(err).to.exist();
+            expect(instance).to.not.exist();
+            expect(err).to.equal(error);
+            done();
+          });
+        });
+      });
+    });
     describe('fetchInternalIpForHostname', function () {
       var dockerHost =  'http://10.12.199.84:4242';
       beforeEach(function (done) {
@@ -292,7 +375,7 @@ describe('user', function () {
         it('should cb internal ip of dep instance if found', function (done) {
           var hostname = 'api-codenow.runnableapp.com';
           var localIp = '10.0.3.0';
-          ctx.fetchDepSpy.yieldsAsync(null, ctx.mockDep);
+          ctx.fetchDepSpy.yieldsAsync(null, ctx.mockDep, ctx.in);
           ctx.fetchMasterSpy.yieldsAsync(null, null);
           ctx.user.fetchInternalIpForHostname(hostname, localIp, dockerHost, function (err, hostIp) {
             expect(err).to.not.exist();

--- a/test/unit-user.js
+++ b/test/unit-user.js
@@ -904,10 +904,7 @@ describe('user', function () {
             var fetchDepCb = last(ctx.fetchDepSpy.firstCall.args);
             fetchDepCb(null, ctx.mockDep);
 
-            expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
-            expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
-            var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
-            fetchMasterCb(null, ctx.mockInstance);
+            expect(ctx.fetchMasterSpy.notCalled).to.be.true();
           });
         });
 

--- a/test/unit-user.js
+++ b/test/unit-user.js
@@ -815,6 +815,7 @@ describe('user', function () {
               owner: {
                 username: 'tjmehta'
               },
+              isolated: 'asdfasdfsadfsadf',
               container: {
                 inspect: {}
               }
@@ -869,17 +870,21 @@ describe('user', function () {
               expect(backendUrl).to.equal(ctx.masterBackendUrl);
               done();
             });
-            expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
-            expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
-            var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
-            fetchMasterCb(null, ctx.mockInstance);
+
             expect(ctx.fetchDepSpy.calledOnce).to.be.true();
             expect(ctx.fetchDepSpy.firstCall.args[0]).to.deep.equal({
               hostname: parseUrl(refererUrl).hostname
             });
             expect(ctx.fetchDepSpy.firstCall.args[1]).to.equal(parseUrl(url).hostname);
             var fetchDepCb = last(ctx.fetchDepSpy.firstCall.args);
-            fetchDepCb(null, null);
+            fetchDepCb(null, null, ctx.mockInstance);
+
+            expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
+            expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
+            expect(ctx.fetchMasterSpy.firstCall.args[1]).to.deep.equal('asdfasdfsadfsadf');
+
+            var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
+            fetchMasterCb(null, ctx.mockInstance);
           });
 
           it('should cb backend url of master instance if dep not found', function (done) {
@@ -891,10 +896,6 @@ describe('user', function () {
               expect(backendUrl).to.equal(ctx.depBackendUrl);
               done();
             });
-            expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
-            expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
-            var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
-            fetchMasterCb(null, ctx.mockInstance);
             expect(ctx.fetchDepSpy.calledOnce).to.be.true();
             expect(ctx.fetchDepSpy.firstCall.args[0]).to.deep.equal({
               hostname: parseUrl(refererUrl).hostname
@@ -902,6 +903,11 @@ describe('user', function () {
             expect(ctx.fetchDepSpy.firstCall.args[1]).to.equal(parseUrl(url).hostname);
             var fetchDepCb = last(ctx.fetchDepSpy.firstCall.args);
             fetchDepCb(null, ctx.mockDep);
+
+            expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
+            expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
+            var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
+            fetchMasterCb(null, ctx.mockInstance);
           });
         });
 
@@ -916,6 +922,13 @@ describe('user', function () {
               expect(err).to.equal(fetchErr);
               done();
             });
+            expect(ctx.fetchDepSpy.calledOnce).to.be.true();
+            expect(ctx.fetchDepSpy.firstCall.args[0]).to.deep.equal({
+              hostname: parseUrl(refererUrl).hostname
+            });
+            expect(ctx.fetchDepSpy.firstCall.args[1]).to.equal(parseUrl(url).hostname);
+            var fetchDepCb = last(ctx.fetchDepSpy.firstCall.args);
+            fetchDepCb(null, null);
             expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
             expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
             var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
@@ -931,10 +944,6 @@ describe('user', function () {
               expect(err).to.equal(fetchErr);
               done();
             });
-            expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
-            expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
-            var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
-            fetchMasterCb(null, ctx.mockInstance);
             expect(ctx.fetchDepSpy.calledOnce).to.be.true();
             expect(ctx.fetchDepSpy.firstCall.args[0]).to.deep.equal({
               hostname: parseUrl(refererUrl).hostname
@@ -960,17 +969,18 @@ describe('user', function () {
                   expect(err.message).to.match(/no container/);
                   done();
                 });
-                expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
-                expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
-                var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
-                fetchMasterCb(null, ctx.mockInstance);
+
                 expect(ctx.fetchDepSpy.calledOnce).to.be.true();
                 expect(ctx.fetchDepSpy.firstCall.args[0]).to.deep.equal({
                   hostname: parseUrl(refererUrl).hostname
                 });
                 expect(ctx.fetchDepSpy.firstCall.args[1]).to.equal(parseUrl(url).hostname);
                 var fetchDepCb = last(ctx.fetchDepSpy.firstCall.args);
-                fetchDepCb(null, null);
+                fetchDepCb(null, null); expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
+
+                expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
+                var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
+                fetchMasterCb(null, ctx.mockInstance);
               });
             });
 
@@ -987,10 +997,7 @@ describe('user', function () {
                   expect(err.message).to.match(/instance/).to.match(/inspect failed/);
                   done();
                 });
-                expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
-                expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
-                var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
-                fetchMasterCb(null, ctx.mockInstance);
+
                 expect(ctx.fetchDepSpy.calledOnce).to.be.true();
                 expect(ctx.fetchDepSpy.firstCall.args[0]).to.deep.equal({
                   hostname: parseUrl(refererUrl).hostname
@@ -998,6 +1005,11 @@ describe('user', function () {
                 expect(ctx.fetchDepSpy.firstCall.args[1]).to.equal(parseUrl(url).hostname);
                 var fetchDepCb = last(ctx.fetchDepSpy.firstCall.args);
                 fetchDepCb(null, null);
+
+                expect(ctx.fetchMasterSpy.calledOnce).to.be.true();
+                expect(ctx.fetchMasterSpy.firstCall.args[0]).to.deep.equal(parseUrl(url).hostname);
+                var fetchMasterCb = last(ctx.fetchMasterSpy.firstCall.args);
+                fetchMasterCb(null, ctx.mockInstance);
               });
             });
           });


### PR DESCRIPTION
This adds the ability for isolated containers to default (during dns) to their isolated brethren instead of just master

Add promises
add fetch for isolated instance
#### Dependencies
- [x] CodeNow/api#1511
#### Reviewers
- [x] @anandkumarpatel  
