### PR TITLE
Filter out null objects in the containers attrs

### DIFF
--- a/lib/models/instance.js
+++ b/lib/models/instance.js
@@ -461,15 +461,17 @@ Instance.prototype.setupChildren = function (attrs) {
     extend(containerInspectState, startingState);
   }
   if (attrs.containers) {
-    attrs.containers = attrs.containers.map(function (container) {
-      // container error don't have the container idAttribute
-      // so they throw warnings when they are added to the
-      // containers collection
-      if (container.error && !container.dockerContainer) {
-        container.dockerContainer = uuid();
-      }
-      return container;
-    });
+    attrs.containers = attrs.containers
+      .filter(exists)
+      .map(function (container) {
+        // container error don't have the container idAttribute
+        // so they throw warnings when they are added to the
+        // containers collection
+        if (container.error && !container.dockerContainer) {
+          container.dockerContainer = uuid();
+        }
+        return container;
+      });
     this.containers = this.newContainers(attrs.containers, {
       qs: {},
       instanceName: attrs.name,


### PR DESCRIPTION
Gamma is currently experiencing an issue where an instance is being sent with a null item in the container array.  We shouldn't let this break the frontend
