### PR TITLE
keypather.has -> keypather.get

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -112,7 +112,7 @@ User.prototype.githubLogin = function (accessToken, cb) {
 
 User.prototype.parse = function (attrs) {
   // Special property only exposed in /user/me and not exposed in the /user?githugOrgName route
-  if (keypather.has(this, 'attrs.bigPoppaUser') && !keypather.has(attrs, 'bigPoppaUser')) {
+  if (keypather.get(this, 'attrs.bigPoppaUser') && !keypather.get(attrs, 'bigPoppaUser')) {
     attrs.bigPoppaUser = this.attrs.bigPoppaUser;
   }
   return attrs;


### PR DESCRIPTION
- `.has` is short for `hasOwnProperty` which is `true` if value is set and is `null`
- Hence, this didn't work for when it was `null` :(
